### PR TITLE
Add epel repository to insrtall Nginx

### DIFF
--- a/hosts/ketchup/inventory
+++ b/hosts/ketchup/inventory
@@ -13,6 +13,7 @@ ketchup_port=80
 ansible_ssh_user=vagrant
 ansible_ssh_private_key_file="~/vagrant/infraci/.vagrant/machines/ketchup/virtualbox/private_key"
 
+use_epel_repo=True
 use_nginx_proxy=False
 
 ketchup_repos="https://github.com/infra-ci-book/app-contents.git"
@@ -23,6 +24,7 @@ ketchup_data_dir="app-contents/contents/data"
 ansible_ssh_user=vagrant
 ansible_ssh_private_key_file="~/vagrant/infraci/.vagrant/machines/ketchup-nginx/virtualbox/private_key"
 
+use_epel_repo=True
 use_nginx_proxy=True
 
 nginx_http_port=80

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -19,6 +19,12 @@
     with_items:
       - httpd_can_network_connect
 
+  - name: Install nginx.conf for Nginx
+    copy:
+      src: nginx.conf
+      dest: /etc/nginx/nginx.conf
+      backup: yes
+
   - name: Disable default.conf for Ngnix
     command: mv /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf.org
     ignore_errors: True

--- a/roles/repos_el/files/nginx-centos-7.repo
+++ b/roles/repos_el/files/nginx-centos-7.repo
@@ -1,5 +1,5 @@
 [nginx]
-name=nginx repo
-baseurl=http://nginx.org/packages/centos/7/$basearch/
-gpgcheck=0
-enabled=1
+name = nginx repo
+baseurl = http://nginx.org/packages/centos/7/$basearch/
+gpgcheck = 0
+enabled = 1

--- a/roles/repos_el/tasks/main.yml
+++ b/roles/repos_el/tasks/main.yml
@@ -15,7 +15,22 @@
     copy:
       src: '{{ item }}'
       dest: '/etc/yum.repos.d/{{ item }}'
-    with_items: "{{ yum_online_repo_files }}"
+    with_items: '{{ yum_online_repo_files }}'
+
+  - block:
+    - name: Enable epel repository
+      ini_file:
+        dest: /etc/yum.repos.d/epel-7.repo
+        section: epel
+        option: enabled
+        value: 1
+    - name: Disable officuial Nginx repository
+      ini_file:
+        dest: /etc/yum.repos.d/nginx-centos-7.repo
+        section: nginx
+        option: enabled
+        value: 0
+    when: 'use_epel_repo|bool'
 
   become: True
 

--- a/roles/repos_el/vars/default.yml
+++ b/roles/repos_el/vars/default.yml
@@ -1,3 +1,4 @@
 ---
 yum_online_repo_files:
   - nginx-centos-7.repo
+  - epel-7.repo


### PR DESCRIPTION
- With this fix, you can choose epel repo or official repo to install Nginx
- Fix issue #6